### PR TITLE
Add lab manager mailing to update-repo.sh

### DIFF
--- a/scripts/configs/config-leads.json
+++ b/scripts/configs/config-leads.json
@@ -24,5 +24,5 @@
     "thrive-dataset": "gbuzzell",
     "working-memory-error-dataset": "fzaki001",
     "technician": "nwelch",
-    "lab-manager": "ndclab"
+    "lab-manager": "llaplace"
 }

--- a/scripts/updates/update-repo.sh
+++ b/scripts/updates/update-repo.sh
@@ -9,7 +9,7 @@ ARCHIVED_REPOS="rwe-dataset social-context-dataset social-context-beta-dataset s
 ARCHIVED_REPOS+=" post-error-ddm pepper-pipeline"
 ###
 LOG_PATH="/home/data/NDClab/other/logs/repo-updates"
-LAB_MGR="ndclab"
+LAB_MGR=$(grep "lab-manager" $TOOL_PATH/lab-devOps/scripts/configs/config-leads.json | cut -d":" -f2 | tr -d '"",')
 LAB_TECH=$(grep "technician" $TOOL_PATH/lab-devOps/scripts/configs/config-leads.json | cut -d":" -f2 | tr -d '"",')
 repoarr=()
 

--- a/scripts/updates/update-repo.sh
+++ b/scripts/updates/update-repo.sh
@@ -47,7 +47,7 @@ then
         if [[ $PROJ_LEAD == "" ]]; then
             echo "Can't find proj lead for $repo, emailing lab tech"
             echo "git status detects unpushed changes for $repo, no project lead found in config-leads.json." | mail -s \
-            "$repo needs re-sync with Github" "$LAB_TECH@fiu.edu"
+            "$repo needs re-sync with Github" "$LAB_TECH@fiu.edu" "$LAB_MGR@fiu.edu"
         else
             # email proj lead
             echo "Emailing project lead $PROJ_LEAD for $repo"


### PR DESCRIPTION
**Changes:**
* Add user `llaplace` to `config-leads.json` under the `lab-manager` role
* Get `LAB_MGR` by parsing the `lab-manager` role of `config-leads.json`
* Additionally email `LAB_MGR`@fiu.edu when unpushed changes are found in a repo with no project lead defined in `config-leads.json`