### PR TITLE
Add --ignore-before flag

### DIFF
--- a/scripts/monitor/hallMonitor2/hallmonitor/hmutils.py
+++ b/scripts/monitor/hallMonitor2/hallmonitor/hmutils.py
@@ -354,6 +354,13 @@ def validated_dataset(input):
     return dataset
 
 
+def validated_date(input):
+    try:
+        return datetime.datetime.strptime(input, "%Y-%m-%d").date()
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{input} is not a valid date")
+
+
 def validated_redcap_replace(input):
     col_re = r"[^:\s]+"
     if not re.fullmatch(col_re, input):
@@ -391,6 +398,12 @@ def get_args():
         "--child-data",
         action="store_true",
         help="dataset includes child data",
+    )
+    parser.add_argument(
+        "-i",
+        "--ignore-before",
+        type=validated_date,
+        help="automatically pass all identifiers whose files were last modified before this date",
     )
     parser.add_argument(
         "-l",

--- a/scripts/monitor/hallMonitor2/hallmonitor/hmutils.py
+++ b/scripts/monitor/hallMonitor2/hallmonitor/hmutils.py
@@ -529,6 +529,19 @@ def get_deviation_string(filename):
     return str(dev_str)
 
 
+def file_last_modified_date(file_path):
+    """
+    Get the last modified time of a file.
+
+    Args:
+        file_path (str): The path to the file.
+
+    Returns:
+        datetime.datetime: The last time the file was modified.
+    """
+    return datetime.datetime.fromtimestamp(os.path.getmtime(file_path))
+
+
 def get_timestamp():
     dt = datetime.datetime.now(TZ_INFO)
     return dt.strftime(DT_FORMAT)

--- a/scripts/monitor/hallMonitor2/hallmonitor/tests/integration/base_cases.py
+++ b/scripts/monitor/hallMonitor2/hallmonitor/tests/integration/base_cases.py
@@ -837,6 +837,7 @@ class TestCase(ABC):
         class MockNamespace:
             dataset = self.case_dir
             child_data = None
+            ignore_before_date = None
             legacy_exceptions = False
             no_color = False
             no_qa = False
@@ -851,7 +852,7 @@ class TestCase(ABC):
 
         return MockNamespace()
 
-    def run_validate_data(self):
+    def run_validate_data(self, *args, **kwargs):
         """
         Run validate_data() on the generated data directory and collect errors.
 
@@ -868,8 +869,10 @@ class TestCase(ABC):
         pending = validate_data(
             logger,
             dataset=self.case_dir,
+            *args,
             use_legacy_exceptions=False,
             is_raw=False,
+            **kwargs,
         )
 
         pending_df = pd.DataFrame(pending)
@@ -880,7 +883,7 @@ class TestCase(ABC):
 
         return pending_df
 
-    def run_qa_validation(self) -> str:
+    def run_qa_validation(self, *args, **kwargs) -> str:
         """Run qa_validation() on the generated data directory.
 
         Returns:
@@ -894,7 +897,7 @@ class TestCase(ABC):
 
         error_text = ""
         try:
-            qa_validation(logger, dataset=self.case_dir)
+            qa_validation(logger, dataset=self.case_dir, *args, **kwargs)
         except Exception as err:
             error_text = str(err)
 

--- a/scripts/monitor/hallMonitor2/hallmonitor/tests/integration/test_misc.py
+++ b/scripts/monitor/hallMonitor2/hallmonitor/tests/integration/test_misc.py
@@ -440,3 +440,37 @@ class MissingTaskFromDataDictionaryTestCase(MiscellaneousTestCase):
 
 def test_missing_task_from_data_dictionary(request):
     MissingTaskFromDataDictionaryTestCase.run_test_case(request)
+
+
+class IgnoreBeforeDateTestCase(MiscellaneousTestCase):
+    case_name = "IgnoreBeforeDateTestCase"
+    description = "Sets an ignore date in the future."
+    conditions = ["File with error has a date before the ignore date."]
+    expected_output = "Error is not raised for file with date before ignore date."
+
+    def modify(self, base_files):
+        modified_files = base_files.copy()
+
+        target = f"sub-{self.sub_id}_arrow-alert-v1-1_psychopy_s1_r1_e1.csv"
+        target = self.build_path("s1_r1", "psychopy", target)
+
+        if target not in modified_files:
+            raise FileNotFoundError(f"File matching relative path {target} not found")
+
+        # simulate empty file (0 bytes)
+        modified_files[target] = ""
+
+        return modified_files
+
+    def get_expected_errors(self):
+        # file with error is ignored due to date of last modification
+        return []
+
+    def validate(self):
+        ignore_before_date = datetime.datetime.now() + datetime.timedelta(days=1)
+        error_df = self.run_validate_data(ignore_before_date=ignore_before_date)
+        self.compare_errors(error_df)
+
+
+def test_ignore_before_date(request):
+    IgnoreBeforeDateTestCase.run_test_case(request)

--- a/scripts/monitor/hallMonitor2/hallmonitor/tests/unit/test_args.py
+++ b/scripts/monitor/hallMonitor2/hallmonitor/tests/unit/test_args.py
@@ -1,7 +1,9 @@
 import argparse
+import datetime
 from unittest import mock
 
 import pytest
+
 from hallmonitor.hmutils import (
     get_args,
     validated_dataset,
@@ -172,3 +174,21 @@ def test_get_args_quiet(mock_dataset_dir):
         args = get_args()
         assert args.quiet
         assert not args.verbose
+
+
+def test_get_args_ignore_before(mock_dataset_dir):
+    test_args = [VALID_DATASET, "--ignore-before", "2022-01-01"]
+    with mock.patch("sys.argv", ["program_name"] + test_args):
+        args = get_args()
+        assert args.ignore_before == datetime.date(2022, 1, 1)
+
+
+def test_get_args_ignore_before_bad_date(mock_dataset_dir):
+    base_args = [VALID_DATASET, "--ignore-before"]
+    test_dates = ["2022-01-32", "2022-13-01", "2022-01-01-01", "2022-301-01", "2022-04"]
+    for date in test_dates:
+        with (
+            mock.patch("sys.argv", ["program_name"] + base_args + [date]),
+            pytest.raises(SystemExit),
+        ):
+            get_args()


### PR DESCRIPTION
Allows users to automatically pass identifiers with at least one file that was last modified before some certain date.