### PR TITLE
Implement desired pending-qa behavior on raw check failure

### DIFF
--- a/scripts/monitor/hallMonitor2/hallmonitor/tests/integration/base_cases.py
+++ b/scripts/monitor/hallMonitor2/hallmonitor/tests/integration/base_cases.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Optional
 
 import pandas as pd
 import pytest
@@ -978,6 +979,19 @@ class TestCase(ABC):
             )
         except Exception as err:
             raise RuntimeError("update_tracker exited with error") from err
+
+    def get_qa_checklist(self) -> Optional[pd.DataFrame]:
+        qa_csv_path = os.path.join(
+            self.case_dir,
+            "sourcedata",
+            "pending-qa",
+            "qa-checklist.csv",
+        )
+
+        if not os.path.exists(qa_csv_path):
+            return None
+
+        return pd.read_csv(qa_csv_path)
 
     @abstractmethod
     def validate(self):


### PR DESCRIPTION
Implemented behavior to synchronize `pending-qa/` with the contents of the QA checklist after an identifier fails raw checks. Now, the identifier's files are removed from both `pending-qa/` and the QA checklist. Implemented an integration test to ensure this behavior.

Closes #323.