### PR TITLE
Add nwelch to group.txt

### DIFF
--- a/scripts/configs/group.txt
+++ b/scripts/configs/group.txt
@@ -1,1 +1,1 @@
-gbuzzell,dhunt,jalexand,agarc884,anagarci,khoss005,ostib001,rdick014,apoly003,emach039,smaly002,adunc018,bbead001,blope118,jloui096,lgall049,lwebe013,lsaha003,mbent023,schar107,vguev015,emart459,yniu,brmannin,apena106,crodr644,llaplace,fzaki001,lcruz142,msuar242,dberwal,mabrady,mbuch
+gbuzzell,dhunt,jalexand,agarc884,anagarci,khoss005,ostib001,rdick014,apoly003,emach039,smaly002,adunc018,bbead001,blope118,jloui096,lgall049,lwebe013,lsaha003,mbent023,schar107,vguev015,emart459,yniu,brmannin,apena106,crodr644,llaplace,fzaki001,lcruz142,msuar242,dberwal,mabrady,mbuch,nwelch


### PR DESCRIPTION
Needed for proper enforcement of access control policies. This likely won't stay for long since 1) I leave the lab next week and 2) our ACL management policy may be changing, but this is helpful for current testing.